### PR TITLE
Load config vars before running npm prune

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -65,14 +65,21 @@ elif test -d $cache_dir/node/node_modules; then
   status "Restoring node_modules directory from cache"
   cp -r $cache_dir/node/node_modules $build_dir/
 
-  status "Pruning cached dependencies not specified in package.json"
-  npm prune 2>&1 | indent
+  # Scope config var availability only to `npm ...`
+  (
+    if [ -d "$env_dir" ]; then
+      status "Exporting config vars to environment"
+      export_env_dir $env_dir
+    fi
 
-  if test -f $cache_dir/node/.heroku/node-version && [ $(cat $cache_dir/node/.heroku/node-version) != "$node_version" ]; then
-    status "Node version changed since last build; rebuilding dependencies"
-    npm rebuild 2>&1 | indent
-  fi
+    status "Pruning cached dependencies not specified in package.json"
+    npm prune 2>&1 | indent
 
+    if test -f $cache_dir/node/.heroku/node-version && [ $(cat $cache_dir/node/.heroku/node-version) != "$node_version" ]; then
+      status "Node version changed since last build; rebuilding dependencies"
+      npm rebuild 2>&1 | indent
+    fi
+  )
 fi
 
 # Check and run bower


### PR DESCRIPTION
- This is needed because npm will fail to run if there’s an environment variable (e.g. ${NPM_TOKEN}) in .npmrc